### PR TITLE
TLS 1.2 FileDownloader.cs

### DIFF
--- a/FileDownloader.cs
+++ b/FileDownloader.cs
@@ -526,6 +526,7 @@ namespace wyUpdate.Downloader
                 }
                 else
                 {
+                    ServicePointManager.SecurityProtocol = SecurityProtocolType.Tls | SecurityProtocolType.Ssl3 | (SecurityProtocolType) 3072;
                     downloadData.response = req.GetResponse();
                     downloadData.GetFileSize();
                 }


### PR DESCRIPTION
Specified securtityprotocol for webrequest and added numerical represenation of TLS 1.2 for .NET 4.0 to work with this protocol.